### PR TITLE
Fix for ArgumentError issues

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -34,11 +34,7 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('flutter-first-frame', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
-    }
+    {{flutter_bootstrap_js}}
   </script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>

--- a/lib/src/ui/widgets/content/number_content.dart
+++ b/lib/src/ui/widgets/content/number_content.dart
@@ -32,13 +32,17 @@ class NumberContent extends StatelessWidget {
           valueListenable: InheritedNumberPaginator.of(context).controller,
           builder: (context, currentPage, child) => Row(
             mainAxisAlignment: mainAxisAlignment,
-            children: [
-              _buildPageButton(context, currentPage, 0),
-              if (_frontDotsShouldShow(numberPages, currentPage, availableSpots)) _Dots(),
-              if (numberPages > 1) ..._generateButtonList(context, currentPage, availableSpots),
-              if (_backDotsShouldShow(numberPages, currentPage, availableSpots)) _Dots(),
-              if (numberPages > 1) _buildPageButton(context, currentPage, numberPages - 1),
-            ],
+            children: (availableSpots >= 3)
+                ? [
+                    _buildPageButton(context, currentPage, 0),
+                    if (_frontDotsShouldShow(numberPages, currentPage, availableSpots)) _Dots(),
+                    if (numberPages > 1) ..._generateButtonList(context, currentPage, availableSpots),
+                    if (_backDotsShouldShow(numberPages, currentPage, availableSpots)) _Dots(),
+                    if (numberPages > 1) _buildPageButton(context, currentPage, numberPages - 1),
+                  ]
+                : [
+                    _buildPageButton(context, currentPage, currentPage),
+                  ],
           ),
         );
       },
@@ -49,18 +53,31 @@ class NumberContent extends StatelessWidget {
   /// dots. The very last and first pages are shown independently of this list.
   List<Widget> _generateButtonList(BuildContext context, int currentPage, int availableSpots) {
     final numberPages = InheritedNumberPaginator.of(context).numberPages;
+
     // if dots shown: available minus (2 for first and last pages + 2 for dots)
-    final shownPages = availableSpots -
-        2 -
-        (_backDotsShouldShow(numberPages, currentPage, availableSpots) ? 1 : 0) -
-        (_frontDotsShouldShow(numberPages, currentPage, availableSpots) ? 1 : 0);
+    final backDotsShow = _backDotsShouldShow(numberPages, currentPage, availableSpots);
+    final frontDotsShow = _frontDotsShouldShow(numberPages, currentPage, availableSpots);
+
+    final shownPagesCalc = availableSpots - 2 - (backDotsShow ? 1 : 0) - (frontDotsShow ? 1 : 0);
+    final shownPages = max(0, shownPagesCalc);
+
+    if (shownPages == 0) {
+      return [];
+    }
 
     var minValue = max(1, currentPage - shownPages ~/ 2);
-    final maxValue = min(minValue + shownPages, numberPages - 1);
+
+    var maxValue = min(minValue + shownPages, numberPages - 1);
+
+    // Ensure we show the requested number of pages if possible
     if (maxValue - minValue < shownPages) {
       minValue = (maxValue - shownPages).clamp(1, numberPages - 1);
     }
 
+    // Final safety check: ensure min is never greater than max
+    if (minValue > maxValue) {
+      return [];
+    }
     return List.generate(
       maxValue - minValue,
       (index) => _buildPageButton(context, currentPage, minValue + index),


### PR DESCRIPTION
Closes #38. This PR makes only one of the page buttons show up if there is not enough space to fit everything, and also adds some guards to return an empty list in case we hit weird values.
It also adds a fix to a warning on the web example.
<img width="260" height="500" alt="Screenshot 2026-02-12 at 3 01 44 PM" src="https://github.com/user-attachments/assets/0db37b15-2970-45b3-b996-77714728f435" />
